### PR TITLE
Use gzencode instead of gzcompress

### DIFF
--- a/src/AsseticStaticGzipBundle/Command/DumpCommand.php
+++ b/src/AsseticStaticGzipBundle/Command/DumpCommand.php
@@ -36,7 +36,7 @@ function file_put_contents($filePath, $content)
     if (GzipProperties::$use) {
 
         // check gzip extension
-        if (!function_exists("gzcompress")) {
+        if (!function_exists("gzencode")) {
             throw new \RuntimeException('Unable to find Zlib library');
         }
 
@@ -49,7 +49,7 @@ function file_put_contents($filePath, $content)
             )
         );
 
-        if (false === @\file_put_contents($filePath, gzcompress($content, GzipProperties::$level))) {
+        if (false === @\file_put_contents($filePath, gzencode($content, GzipProperties::$level))) {
             throw new \RuntimeException('Unable to write file ' . $filePath);
         }
     }


### PR DESCRIPTION
When using this bundle to produce gzipped assets chrome wasn't liking what was being served up. Swapping from `gzcompress` to `gzencode` fixed it.

`gzencode` produces a gzip compatible file format. `gzcompress` produces something slightly different.

See here for further details:  http://stackoverflow.com/questions/22950285/how-output-data-with-gzip-header-and-not-deflate-header
